### PR TITLE
added exception subscriber for better comprehension

### DIFF
--- a/src/EventSubscriber/ResponseExceptionSubscriber.php
+++ b/src/EventSubscriber/ResponseExceptionSubscriber.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Novaway\ElasticsearchBundle\EventSubscriber;
+
+use Elastica\Exception\ResponseException as ElasticaResponseException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpFoundation\Response;
+use Novaway\ElasticsearchBundle\Exception\Response\ResponseException;
+
+class ResponseExceptionSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::EXCEPTION => [
+                'process'
+            ]
+        ];
+    }
+
+    public function process(GetResponseForExceptionEvent $event)
+    {
+        $exception = $event->getException();
+        if (!$exception instanceof ElasticaResponseException) {
+            return;
+        }
+        
+        $response = new ResponseException($exception->getRequest(), $exception->getResponse());
+        $event->setException($response);
+    }
+}

--- a/src/Exception/Response/ResponseException.php
+++ b/src/Exception/Response/ResponseException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Novaway\ElasticsearchBundle\Exception\Response;
+
+use Elastica\Exception\ResponseException as ElasticaResponseException;
+use Elastica\Exception\ElasticsearchException;
+use Elastica\Exception\ExceptionInterface;
+use Elastica\Request;
+use Elastica\Response;
+
+class ResponseException extends ElasticaResponseException implements ExceptionInterface
+{
+    /**
+     * Construct Exception.
+     *
+     * @param \Elastica\Request $request
+     * @param \Elastica\Response $response
+     */
+    public function __construct(Request $request, Response $response)
+    {
+        parent::__construct($request, $response);
+        $this->message = $response->getError() . "\n\n\n" . json_encode($response->getFullError(), JSON_PRETTY_PRINT) ;
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -17,5 +17,9 @@
         <service id="Novaway\ElasticsearchBundle\Logger\SearchEventLogger">
             <tag name="kernel.event_subscriber"/>
         </service>
+
+        <service id="Novaway\ElasticsearchBundle\EventSubscriber\ResponseExceptionSubscriber">
+            <tag name="kernel.event_subscriber"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
The Elastica Standard exception doesn't give full Elastic trace, and therefore is not informative enough.

Here we show the full Error in symfony