### PR TITLE
🐛 Fix Exception event subscriber for symfony 5.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "php": "^7.1",
     "elasticsearch/elasticsearch": "^5.2 || ^6.0",
     "ruflin/elastica": "^6.0 || ^7.0",
-    "symfony/http-kernel": "^3.4 || ^4.1 || >=5.1.5",
+    "symfony/http-kernel": "^4.3 || >=5.1.5",
     "symfony/dependency-injection": "^4.2 || ^5.0",
     "symfony/web-profiler-bundle": "^4.2 || ^5.0",
     "symfony/config": "^4.2 || ^5.0",

--- a/src/EventSubscriber/ResponseExceptionSubscriber.php
+++ b/src/EventSubscriber/ResponseExceptionSubscriber.php
@@ -5,7 +5,7 @@ namespace Novaway\ElasticsearchBundle\EventSubscriber;
 
 use Elastica\Exception\ResponseException as ElasticaResponseException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpFoundation\Response;
 use Novaway\ElasticsearchBundle\Exception\Response\ResponseException;
@@ -20,15 +20,13 @@ class ResponseExceptionSubscriber implements EventSubscriberInterface
             ]
         ];
     }
-
-    public function process(GetResponseForExceptionEvent $event)
+    public function process(ExceptionEvent $event)
     {
-        $exception = $event->getException();
+        $exception = $event->getThrowable();
         if (!$exception instanceof ElasticaResponseException) {
             return;
         }
-        
         $response = new ResponseException($exception->getRequest(), $exception->getResponse());
-        $event->setException($response);
+        $event->setThrowable($response);
     }
 }


### PR DESCRIPTION
`GetResponseForExceptionEvent` has been replaced by `ExceptionEvent` in symfony 4.3 and removed from symfony since 5.0.

This MR uses the proper event.

Since versions lower than 4.3 uses `GetResponseForExceptionEvent`, the `composer.jon` configuration has been updated because it's introducing a breaking change.