### PR TITLE
upgrade package required for Sf 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     "ruflin/elastica": "^6.0 || ^7.0",
     "symfony/http-kernel": "^4.3 || >=5.1.5",
     "symfony/dependency-injection": "^4.2 || ^5.0 || ^6.0",
-    "symfony/web-profiler-bundle": "^4.2 || ^5.0",
-    "symfony/config": "^4.2 || ^5.0",
-    "symfony/serializer": "^4.2 || ^5.0",
+    "symfony/web-profiler-bundle": "^4.2 || ^5.0 || ^6.0",
+    "symfony/config": "^4.2 || ^5.0 || ^6.0",
+    "symfony/serializer": "^4.2 || ^5.0 || ^6.0",
     "webmozart/assert": "^1.0",
     "ext-curl": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "elasticsearch/elasticsearch": "^5.2 || ^6.0 || ^7.0",
     "ruflin/elastica": "^6.0 || ^7.0",
     "symfony/http-kernel": "^4.3 || >=5.1.5",
-    "symfony/dependency-injection": "^4.2 || ^5.0",
+    "symfony/dependency-injection": "^4.2 || ^5.0 || ^6.0",
     "symfony/web-profiler-bundle": "^4.2 || ^5.0",
     "symfony/config": "^4.2 || ^5.0",
     "symfony/serializer": "^4.2 || ^5.0",


### PR DESCRIPTION
Upgrade package `symfony/dependency-injection` required for **symfony 6**

```
novaway/elasticsearch-bundle 2.2 requires symfony/dependency-injection ^4.2 || ^5.0 
-> found symfony/dependency-injection[v4.2.0-BETA1, ..., 4.4.x-dev, v5.0.0-BETA1, ..., 5.4.x-dev] 
but the package is fixed to v6.0.3 (lock file version) by a partial update and that version does not match. 
Make sure you list it as an argument for the update command
```