### PR TITLE
Allow removal of old indexes when rebuilding mapping

### DIFF
--- a/src/Provider/IndexProvider.php
+++ b/src/Provider/IndexProvider.php
@@ -77,7 +77,7 @@ class IndexProvider
     /**
      * Update fields mapping
      */
-    public function rebuildMapping(bool $waitForCompletion = true): Index
+    public function rebuildMapping(bool $waitForCompletion = true, bool $removeOldIndexes = false): Index
     {
         $realName = sprintf('%s_rebuild_mapping_%s', $this->name, date('YmdHis'));
         $index = $this->getIndexByName($realName);
@@ -93,7 +93,7 @@ class IndexProvider
             ]
         ]);
 
-        return $this->markAsLive($index, false) ? $index : $this->getIndex();
+        return $this->markAsLive($index, $removeOldIndexes) ? $index : $this->getIndex();
     }
 
     /**


### PR DESCRIPTION
I don't quite get why the removal of old indexes is not done whene rebuilding mapping.

But it leads to dangling indexes, which occupy shards for no reason at all.

To prevent unwanted consequences, i allow to configure it, even if I think it should be done every time