### PR TITLE
Set visibility of IndexProvider->getName as public

### DIFF
--- a/src/Provider/IndexProvider.php
+++ b/src/Provider/IndexProvider.php
@@ -143,7 +143,7 @@ class IndexProvider
         return true;
     }
 
-    protected function getIndexByName($name): Index
+    public function getIndexByName($name): Index
     {
         return new Index($this->eventDispatcher, $this->client, $name);
     }


### PR DESCRIPTION
It is needed to allow an async markAsLive 